### PR TITLE
Bootstrap isolated Cloudflare preview for SAN wiki

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp"
+    },
+    "cloudflare-observability": {
+      "type": "http",
+      "url": "https://observability.mcp.cloudflare.com/mcp"
+    },
+    "cloudflare-builds": {
+      "type": "http",
+      "url": "https://builds.mcp.cloudflare.com/mcp"
+    }
+  }
+}

--- a/cloudflare/wiki-worker.js
+++ b/cloudflare/wiki-worker.js
@@ -1,0 +1,36 @@
+const JSON_HEADERS = {
+  "content-type": "application/json; charset=utf-8",
+  "cache-control": "no-store",
+  "x-content-type-options": "nosniff"
+};
+
+function json(data, init = {}) {
+  return new Response(JSON.stringify(data, null, 2), {
+    ...init,
+    headers: {
+      ...JSON_HEADERS,
+      ...(init.headers || {})
+    }
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/api/health") {
+      return json({
+        ok: true,
+        service: "san-wiki-preview",
+        environment: env.ENVIRONMENT,
+        supabaseConfigured: Boolean(env.SUPABASE_URL && env.SUPABASE_PUBLISHABLE_KEY)
+      });
+    }
+
+    if (url.pathname.startsWith("/api/")) {
+      return json({ ok: false, error: "not_found" }, { status: 404 });
+    }
+
+    return env.ASSETS.fetch(request);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "san-wiki-cloudflare",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "cf:whoami": "wrangler whoami",
+    "cf:types": "wrangler types ./cloudflare/worker-configuration.d.ts",
+    "cf:check": "wrangler check",
+    "cf:dev": "wrangler dev",
+    "cf:dry-run": "wrangler deploy --dry-run",
+    "cf:deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0"
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "san-wiki",
+  "main": "./cloudflare/wiki-worker.js",
+  "compatibility_date": "2026-07-15",
+  "workers_dev": true,
+  "assets": {
+    "directory": "./wiki",
+    "binding": "ASSETS",
+    "not_found_handling": "404-page",
+    "run_worker_first": ["/api/*"]
+  },
+  "vars": {
+    "ENVIRONMENT": "production",
+    "SUPABASE_URL": "https://vppzuzswfispkavrgmpp.supabase.co",
+    "SUPABASE_PUBLISHABLE_KEY": "sb_publishable_8SYf8SKihAYBMDJcQ8SaXQ_GBxax7bH"
+  },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 0.1
+  }
+}


### PR DESCRIPTION
This draft adds an isolated Cloudflare Worker preview configuration for the SAN wiki without replacing the existing Cloudflare Pages, Access, or protected WebXR production architecture.

It adds:

- `wrangler.jsonc` using Workers Static Assets for `wiki/`
- a minimal `/api/health` Worker route
- Wrangler development, validation, dry-run, and deployment scripts
- Cloudflare Code Mode, Observability, and Builds MCP server configuration
- the existing Supabase project URL and publishable browser key only; no service-role or secret key

The intended first deployment target is the Worker's `workers.dev` preview domain. No custom domain, Access policy, DNS record, Pages project, or production binding is changed by this pull request.

Validation still required from a local Codex session authenticated to Cloudflare:

- `npm install`
- `npm run cf:whoami`
- `npm run cf:types`
- `npm run cf:check`
- `npm run cf:dry-run`
- `npm run cf:dev`
- verify `/api/health`
- deploy only after confirming the selected Cloudflare account and Worker name
